### PR TITLE
Modified to take care of no decimal currencies

### DIFF
--- a/elements/community_store_stripe/dashboard_form.php
+++ b/elements/community_store_stripe/dashboard_form.php
@@ -1,37 +1,37 @@
-<?php defined('C5_EXECUTE') or die(_("Access Denied.")); 
+<?php defined('C5_EXECUTE') or die(_("Access Denied."));
 extract($vars);
 ?>
 <div class="form-group">
-    <?=$form->label('stripeCurrency',t('Currency'))?>
-    <?=$form->select('stripeCurrency',$stripeCurrencies,$stripeCurrency)?>
+    <?=$form->label('stripeCurrency', t('Currency'))?>
+    <?=$form->select('stripeCurrency', $stripeCurrencies, $stripeCurrency)?>
 </div>
 
 <div class="form-group">
-    <?=$form->label('stripeGateway',t('Integration Type'))?>
-    <?=$form->select('stripeGateway',$stripeGateways,$stripeGateway)?>
+    <?=$form->label('stripeGateway', t('Integration Type'))?>
+    <?=$form->select('stripeGateway', $stripeGateways, $stripeGateway)?>
 </div>
 
 <div class="form-group">
-    <?=$form->label('stripeMode',t('Mode'))?>
-    <?=$form->select('stripeMode',array('test'=>t('Test'), 'live'=>t('Live')),$stripeMode)?>
+    <?=$form->label('stripeMode', t('Mode'))?>
+    <?=$form->select('stripeMode', ['test' => t('Test'), 'live' => t('Live')], $stripeMode)?>
 </div>
 
 <div class="form-group">
-    <?=$form->label('stripeTestPrivateApiKey',t('Test Secret Key'))?>
+    <?=$form->label('stripeTestPrivateApiKey', t('Test Secret Key'))?>
     <input type="text" name="stripeTestPrivateApiKey" value="<?=$stripeTestPrivateApiKey?>" class="form-control">
 </div>
 
 <div class="form-group">
-    <?=$form->label('stripeTestPublicApiKey',t('Test Publishable Key'))?>
+    <?=$form->label('stripeTestPublicApiKey', t('Test Publishable Key'))?>
     <input type="text" name="stripeTestPublicApiKey" value="<?=$stripeTestPublicApiKey?>" class="form-control">
 </div>
 
 <div class="form-group">
-    <?=$form->label('stripeLivePrivateApiKey',t('Live Secret Key'))?>
+    <?=$form->label('stripeLivePrivateApiKey', t('Live Secret Key'))?>
     <input type="text" name="stripeLivePrivateApiKey" value="<?=$stripeLivePrivateApiKey?>" class="form-control">
 </div>
 
 <div class="form-group">
-    <?=$form->label('stripeLivePublicApiKey',t('Live Publishable Key'))?>
+    <?=$form->label('stripeLivePublicApiKey', t('Live Publishable Key'))?>
     <input type="text" name="stripeLivePublicApiKey" value="<?=$stripeLivePublicApiKey?>" class="form-control">
 </div>

--- a/src/CommunityStore/Payment/Methods/CommunityStoreStripe/CommunityStoreStripePaymentMethod.php
+++ b/src/CommunityStore/Payment/Methods/CommunityStoreStripe/CommunityStoreStripePaymentMethod.php
@@ -6,101 +6,135 @@ use Core;
 use Log;
 use Config;
 use Exception;
-use \Stripe\Stripe;
-use \Stripe\Charge;
+use Stripe\Stripe;
+use Stripe\Charge;
 use Stripe\Error;
-
-use \Concrete\Package\CommunityStore\Src\CommunityStore\Payment\Method as StorePaymentMethod;
-use \Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Calculator as StoreCalculator;
-use \Concrete\Package\CommunityStore\Src\CommunityStore\Customer\Customer as StoreCustomer;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Payment\Method as StorePaymentMethod;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Calculator as StoreCalculator;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Customer\Customer as StoreCustomer;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Price as StorePrice;
 
 class CommunityStoreStripePaymentMethod extends StorePaymentMethod
 {
+    public $gatewayNames = [
+        'stripe_button' => 'Stripe',
+        'stripe_form' => 'Stripe',
+    ];
 
-    public $gatewayNames = array(
-        'stripe_button'=>'Stripe',
-        'stripe_form'=>'Stripe'
-    );
+    private function getCurrencies()
+    {
+        return [
+            'USD' => t('US Dollar'),
+            'EUR' => t('Euro'),
+            'GBP' => t('British Pounds Sterling'),
+            'AUD' => t('Australian Dollar'),
+            'BRL' => t('Brazilian Real'),
+            'CAD' => t('Canadian Dollar'),
+            'CLP' => t('Chilean Peso'),
+            'CZK' => t('Czech Koruna'),
+            'DKK' => t('Danish Krone'),
+            'HKD' => t('Hong Kong Dollar'),
+            'HUF' => t('Hungarian Forint'),
+            'IRR' => t('Iranian Rial'),
+            'ILS' => t('Israeli Shekel'),
+            'JPY' => t('Japanese Yen'),
+            'MYR' => t('Malaysian Ringgit'),
+            'MXN' => t('Mexican Peso'),
+            'NZD' => t('New Zealand Dollar'),
+            'NOK' => t('Norwegian Krone'),
+            'PHP' => t('Philippine Peso'),
+            'PLN' => t('Polish Zloty'),
+            'RUB' => t('Russian Rubles'),
+            'SGD' => t('Singapore Dollar'),
+            'KRW' => t('South Korean Won'),
+            'SEK' => t('Swedish Krona'),
+            'CHF' => t('Swiss Franc)'),
+            'TWD' => t('Taiwan New Dollar'),
+            'THB' => t('Thai Baht'),
+            'TRY' => t('Turkish Lira'),
+            'VND' => t('Vietnamese Dong'),
+        ];
+    }
+
+    private function getCurrencyMultiplier($currency)
+    {
+        return StorePrice::isZeroDecimalCurrency($currency) ? 1 : 100;
+    }
 
     public function dashboardForm()
     {
         $this->set('stripeMode', Config::get('community_store_stripe.mode'));
-        $this->set('stripeGateway',Config::get('community_store_stripe.gateway'));
-        $this->set('stripeCurrency',Config::get('community_store_stripe.currency'));
-        $this->set('stripeTestPublicApiKey',Config::get('community_store_stripe.testPublicApiKey'));
-        $this->set('stripeLivePublicApiKey',Config::get('community_store_stripe.livePublicApiKey'));
-        $this->set('stripeTestPrivateApiKey',Config::get('community_store_stripe.testPrivateApiKey'));
-        $this->set('stripeLivePrivateApiKey',Config::get('community_store_stripe.livePrivateApiKey'));
-        $this->set('form',Core::make("helper/form"));
+        $this->set('stripeGateway', Config::get('community_store_stripe.gateway'));
+        $this->set('stripeCurrency', Config::get('community_store_stripe.currency'));
+        $this->set('stripeTestPublicApiKey', Config::get('community_store_stripe.testPublicApiKey'));
+        $this->set('stripeLivePublicApiKey', Config::get('community_store_stripe.livePublicApiKey'));
+        $this->set('stripeTestPrivateApiKey', Config::get('community_store_stripe.testPrivateApiKey'));
+        $this->set('stripeLivePrivateApiKey', Config::get('community_store_stripe.livePrivateApiKey'));
+        $this->set('form', Core::make("helper/form"));
 
-        $gateways = array(
-            'stripe_button'=>'Button',
-            'stripe_form'=>'Form'
-        );
+        $gateways = [
+            'stripe_button' => 'Button',
+            'stripe_form' => 'Form',
+        ];
 
-        $this->set('stripeGateways',$gateways);
+        $this->set('stripeGateways', $gateways);
 
-        $currencies = array(
-        	'USD'=>t('US Dollars'),
-        	'CAD'=>t('Canadian Dollar'),
-        	'AUD'=>t('Australian Dollar'),
-        	'GBP'=>t('British Pound'),
-        	'EUR'=>t('Euro'),
-            'CHF'=>t('Swiss Franc')
-        );
-
-        $this->set('stripeCurrencies',$currencies);
+        $this->set('stripeCurrencies', $this->getCurrencies());
     }
-    
+
     public function save(array $data = [])
     {
-        Config::save('community_store_stripe.mode',$data['stripeMode']);
-        Config::save('community_store_stripe.gateway',$data['stripeGateway']);
-        Config::save('community_store_stripe.currency',$data['stripeCurrency']);
-        Config::save('community_store_stripe.testPublicApiKey',$data['stripeTestPublicApiKey']);
-        Config::save('community_store_stripe.livePublicApiKey',$data['stripeLivePublicApiKey']);
-        Config::save('community_store_stripe.testPrivateApiKey',$data['stripeTestPrivateApiKey']);
-        Config::save('community_store_stripe.livePrivateApiKey',$data['stripeLivePrivateApiKey']);
+        Config::save('community_store_stripe.mode', $data['stripeMode']);
+        Config::save('community_store_stripe.gateway', $data['stripeGateway']);
+        Config::save('community_store_stripe.currency', $data['stripeCurrency']);
+        Config::save('community_store_stripe.testPublicApiKey', $data['stripeTestPublicApiKey']);
+        Config::save('community_store_stripe.livePublicApiKey', $data['stripeLivePublicApiKey']);
+        Config::save('community_store_stripe.testPrivateApiKey', $data['stripeTestPrivateApiKey']);
+        Config::save('community_store_stripe.livePrivateApiKey', $data['stripeLivePrivateApiKey']);
     }
-    public function validate($args,$e)
+
+    public function validate($args, $e)
     {
         return $e;
     }
+
     public function checkoutForm()
     {
         $mode = Config::get('community_store_stripe.mode');
-        $this->set('mode',$mode);
-        $this->set('gateway',Config::get('community_store_stripe.gateway'));
-        $this->set('currency',Config::get('community_store_stripe.currency'));
+        $this->set('mode', $mode);
+        $this->set('gateway', Config::get('community_store_stripe.gateway'));
+        $this->set('currency', Config::get('community_store_stripe.currency'));
 
         if ($mode == 'live') {
-            $this->set('publicAPIKey',Config::get('community_store_stripe.livePublicApiKey'));
+            $this->set('publicAPIKey', Config::get('community_store_stripe.livePublicApiKey'));
         } else {
-            $this->set('publicAPIKey',Config::get('community_store_stripe.testPublicApiKey'));
+            $this->set('publicAPIKey', Config::get('community_store_stripe.testPublicApiKey'));
         }
 
         $customer = new StoreCustomer();
 
         $this->set('email', $customer->getEmail());
-        $this->set('form',Core::make("helper/form"));
-        $this->set('amount',  number_format(StoreCalculator::getGrandTotal() * 100, 0, '', ''));
+        $this->set('form', Core::make("helper/form"));
+        $currencyMultiplier = StorePrice::getCurrencyMultiplier(Config::get('community_store_stripe.currency'));
+        $this->set('amount', number_format(StoreCalculator::getGrandTotal() * $currencyMultiplier, 0, '', ''));
 
         $pmID = StorePaymentMethod::getByHandle('community_store_stripe')->getID();
-        $this->set('pmID',$pmID);
-        $years = array();
+        $this->set('pmID', $pmID);
+        $years = [];
         $year = date("Y");
-        for($i=0;$i<15;$i++){
-            $years[$year+$i] = $year+$i;
+        for ($i = 0; $i < 15; ++$i) {
+            $years[$year + $i] = $year + $i;
         }
-        $this->set("years",$years);
+        $this->set("years", $years);
     }
-    
+
     public function submitPayment()
     {
         $customer = new StoreCustomer();
-        
+
         $currency = Config::get('community_store_stripe.currency');
-        $mode =  Config::get('community_store_stripe.mode');
+        $currencyMultiplier = StorePrice::getCurrencyMultiplier($currency);
+        $mode = Config::get('community_store_stripe.mode');
 
         if ($mode == 'test') {
             $privateKey = Config::get('community_store_stripe.testPrivateApiKey');
@@ -111,18 +145,25 @@ class CommunityStoreStripePaymentMethod extends StorePaymentMethod
         \Stripe\Stripe::setApiKey($privateKey);
         $token = $_POST['stripeToken'];
         $genericError = false;
-        
+
         try {
-            $response = \Stripe\Charge::create(array("amount" => round(StoreCalculator::getGrandTotal(), 2) * 100, "currency" => $currency, "source" => $token));
-            return array('error'=>0, 'transactionReference'=>$response->id);
-        } catch(\Stripe\Error\Card $e) {
+            if ($currencyMultiplier === 1) {
+                $amount = StoreCalculator::getGrandTotal();
+            } elseif ($currencyMultiplier === 100) {
+                $amount = round(StoreCalculator::getGrandTotal(), 2);
+            }
+
+            $response = \Stripe\Charge::create(["amount" => $amount * $currencyMultiplier, "currency" => $currency, "source" => $token]);
+
+            return ['error' => 0, 'transactionReference' => $response->id];
+        } catch (\Stripe\Error\Card $e) {
             // Since it's a decline, \Stripe\Error\Card will be caught
             $body = $e->getJsonBody();
-            $err  = $body['error'];
-            return array('error'=>1,'errorMessage'=> $err['message']);
+            $err = $body['error'];
 
+            return ['error' => 1, 'errorMessage' => $err['message']];
         } catch (\Stripe\Error\RateLimit $e) {
-        // Too many requests made to the API too quickly
+            // Too many requests made to the API too quickly
             $genericError = true;
             $errors[] = $e;
         } catch (\Stripe\Error\InvalidRequest $e) {
@@ -149,21 +190,20 @@ class CommunityStoreStripePaymentMethod extends StorePaymentMethod
         // Something else happened, completely unrelated to Stripe
         }
         if ($genericError) {
-            foreach($errors as $error) {
+            foreach ($errors as $error) {
                 $body = $error->getJsonBody();
-                $err  = $body['error'];
-                Log::addEntry('Stripe error.'."\n".'Status is:' . $error->getHttpStatus() . "\n".'Type is:' . $err['type'] . "\n".'Code is:' . $err['code'] . "\n".'Param is:' . $err['param'] . "\n".'Message is:' . $err['message'] . "\n", t('Community Store Stripe'));
+                $err = $body['error'];
+                Log::addEntry('Stripe error.' . "\n" . 'Status is:' . $error->getHttpStatus() . "\n" . 'Type is:' . $err['type'] . "\n" . 'Code is:' . $err['code'] . "\n" . 'Param is:' . $err['param'] . "\n" . 'Message is:' . $err['message'] . "\n", t('Community Store Stripe'));
             }
-           return array('error'=>1,'errorMessage'=> t('Something went wrong with this transaction.'));
-        }
 
+            return ['error' => 1, 'errorMessage' => t('Something went wrong with this transaction.')];
+        }
     }
 
     public function getName()
     {
         return 'Stripe';
     }
-    
 }
 
 return __NAMESPACE__;


### PR DESCRIPTION
Stripe deals only in cents so all amounts must be multiplied by 100 except for no decimal currencies that should be left as is.

This simply checks if the currency takes decimals or not and gets a multiplier depending on the result.

It requires modifications made to the store in a recent store pull request I sent.