### PR TITLE
Add support for stripe.js v3 elements

### DIFF
--- a/elements/community_store_stripe/checkout_form.php
+++ b/elements/community_store_stripe/checkout_form.php
@@ -5,9 +5,11 @@ extract($vars);
 <?php if ($gateway == 'stripe_button') {
     Loader::packageElement('stripe/stripe_button', 'community_store_stripe', $vars);
 } ?>
-
 <?php if ($gateway == 'stripe_form') {
     Loader::packageElement('stripe/stripe_form', 'community_store_stripe', $vars);
+} ?>
+<?php if ($gateway == 'stripe_form_elements') {
+    Loader::packageElement('stripe/stripe_form_elements', 'community_store_stripe', $vars);
 } ?>
 <?php } else { ?>
 <p class="alert alert-warning"><?php t('API Keys not entered');?></p>

--- a/elements/stripe/stripe_form_elements.php
+++ b/elements/stripe/stripe_form_elements.php
@@ -1,0 +1,88 @@
+<?php defined('C5_EXECUTE') or die(_("Access Denied.")); ?>
+<script src="<?= str_replace('/index.php/', '/', URL::to('packages/community_store_stripe/js/jquery.payment.min.js')); ?>"></script>
+<script type="text/javascript" src="https://js.stripe.com/v3/"></script>
+
+<script>
+    $(window).on('load', function() {
+        var form = $('#store-checkout-form-group-payment');
+        var submitButton = form.find(".store-btn-complete-order");
+		var errorMessage = $('#cardErrors');
+		var stripe = Stripe('<?= $publicAPIKey; ?>');
+		var elements = stripe.elements();
+		var cardNumber = elements.create('cardNumber');
+		var cardExpiry = elements.create('cardExpiry');
+		var cardCvc = elements.create('cardCvc');
+		
+		cardNumber.mount('#cardNumber');
+		cardExpiry.mount('#cardExpiry');
+		cardCvc.mount('#cardCVC');
+		
+		function stripeTokenHandler(token) {
+			var domForm = form.get(0); // Code modified from stripe docs. TODO: rewrite for jquery
+			var hiddenInput = document.createElement('input');
+			hiddenInput.setAttribute('type', 'hidden');
+			hiddenInput.setAttribute('name', 'stripeToken');
+			hiddenInput.setAttribute('value', token.id);
+			domForm.appendChild(hiddenInput);
+			domForm.submit();
+		}
+
+		function createToken() {
+			stripe.createToken(cardNumber).then(function(result) {
+				if (result.error) {
+					form.addClass('has-error');
+					errorMessage.show();
+					errorMessage.text(result.error.message);
+					submitButton.removeAttr('disabled');
+					submitButton.val('<?= t('Complete Order'); ?>');
+				} else {
+					stripeTokenHandler(result.token);
+				}
+			});
+		};
+
+        form.submit(function(e) {
+            var currentpmid = $('input[name="payment-method"]:checked:first').data('payment-method-id');
+            if (currentpmid == <?= $pmID; ?>) {
+                e.preventDefault();
+				submitButton.prop('disabled', true);
+                submitButton.val('<?= t('Processing...'); ?>');
+				createToken();
+            }
+        });
+    });
+
+
+</script>
+
+
+<div class="store-credit-card-boxpanel panel panel-default">
+    <div class="panel-body">
+		<div id="cardErrors" style="display:none;" class="alert alert-danger" role="alert"></div>
+        <div class="row">
+            <div class="col-xs-12">
+                <div class="form-group">
+                    <label for="cardNumber"><?= t('Card Number'); ?></label>
+                    <div class="input-group">
+                        <div id="cardNumber" class="form-control ccm-input-text"></div>
+                        <span class="input-group-addon"><i class="fa fa-credit-card"></i></span>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-xs-7 col-md-7">
+                <div class="form-group">
+                    <label for="cardExpiry"><?= t('Expiration Date'); ?></label>
+                    <div id="cardExpiry" class="form-control ccm-input-text"></div>
+                </div>
+            </div>
+            <div class="col-xs-5 col-md-5 pull-right">
+                <div class="form-group">
+                    <label for="cardCVC"><?= t('CV Code'); ?></label>
+                    <div id="cardCVC" class="form-control ccm-input-text"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/CommunityStore/Payment/Methods/CommunityStoreStripe/CommunityStoreStripePaymentMethod.php
+++ b/src/CommunityStore/Payment/Methods/CommunityStoreStripe/CommunityStoreStripePaymentMethod.php
@@ -20,6 +20,7 @@ class CommunityStoreStripePaymentMethod extends StorePaymentMethod
     public $gatewayNames = [
         'stripe_button' => 'Stripe',
         'stripe_form' => 'Stripe',
+        'stripe_form_elements' => 'Stripe',
     ];
 
     private function getCurrencies()
@@ -69,6 +70,7 @@ class CommunityStoreStripePaymentMethod extends StorePaymentMethod
         $this->set('form', Core::make("helper/form"));
 
         $gateways = [
+			'stripe_form_elements' => 'Form: Stripe.js API v3 Elements',
             'stripe_button' => 'Button',
             'stripe_form' => 'Form',
         ];


### PR DESCRIPTION
As the title suggests this pull request adds support for stripe.js v3 elements. It adds support as a separate 'gateway' form so it is non-destructive and won't affect functionality if an existing installation is upgraded. 

Stripe.js v3 is pretty powerful so there are lots of features and improvements that could be added. However, the code in this request is sufficient to add basic support for the new API. This code can be refined, tested, and improved over time.

Only basic testing has been completed so far. However, I'll be pushing this code to two live installations and I'll update as issues are discovered and corrected. In the meantime, you may want to mark this gateway as experimental.